### PR TITLE
Add missing script file referenced on composer

### DIFF
--- a/bin/phpcs-changed.sh
+++ b/bin/phpcs-changed.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+FILES=$(git ls-files -om --exclude-standard);
+if [ -n "$FILES" ]; then
+	phpcs "$FILES"
+fi


### PR DESCRIPTION
Just adding the `phpcs-changed.sh` script that is referenced on composer.json.